### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "tests",
   "dependencies": {
     "express": "~4.12.0",
-    "chai": "latest",
-    "chai-as-promised": "latest",
+    "chai": "2.1.2",
+    "chai-as-promised": "6.0.0",
     "colors": "latest",
     "grunt": "~0.4.5",
     "grunt-concurrent": "latest",


### PR DESCRIPTION
The Saucelabs tests fails because the npm install fails to load "chai" the package. The 6.0.0 version of chai-as-promised needs <4.x version of chai. I have fixed the version of both these packages. I see no reason why we should advance the versions of these packages for a test template.